### PR TITLE
Unset the error handler before stopping the language server.

### DIFF
--- a/src/ChapelLanguageClient.ts
+++ b/src/ChapelLanguageClient.ts
@@ -314,6 +314,7 @@ export abstract class ChapelLanguageClient {
   stop(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.client && this.state === LanguageClientState.RUNNING) {
+        this.client.errorHandler = () => {};
         this.client.stop().catch(reject);
         this.client.dispose();
         this.client = undefined;


### PR DESCRIPTION
This makes sure the 'unrecoverable error -- exited with code 0' doesn't print when trying to restart LSP etc.

Reviewed by @jabraham17 -- thanks!