### PR TITLE
Use new name to avoid conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chapel-vscode",
-  "displayName": "Chapel",
+  "displayName": "Chapel Language",
   "description": "A collection of development tools for programming in Chapel",
   "version": "0.0.2",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chapel-vscode",
   "displayName": "Chapel",
   "description": "A collection of development tools for programming in Chapel",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "engines": {
     "vscode": "^1.70.0"
   },


### PR DESCRIPTION
Change the extension to use the display name `Chapel Language`

This PR also bumps the version number

Not reviewed - trivial