### PR TITLE
Bundle of fixes/improvements to extension

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,9 @@
+# Documentation for Extension Developers
+
+This document is intended for developers who want to contribute to the Chapel extension for Visual Studio Code.
+
+## Building locally
+
+To build and test the extension locally in debug mode, you can use the Run/Debug tab to launch the extension in a new VSCode window (or press `F5`).
+
+For some debugging purposes, it may be useful to build a local binary of the extension using `vsce`. To do this, run `vsce package -o bin/chapel.vsix` from the root of the repository. This can then be installed in VSCode by selecting "Install from VSIX" in the Extensions view, or by running `code --install-extension bin/chapel.vsix`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   - Generic Instantiations: inspect generic code with helpful annotations
   - Dead Code: highlight dead code that will never execute
 
-> **_:warning: CAUTION:_**
+> **_CAUTION:_**
 > These features use a work-in-progress resolver for Chapel called Dyno to further
 > inspect your code. To enable these features, use Dyno by setting
 > `chapel.chpl-language-server.resolver` to `true`. Enabling the Dyno resolver

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chapel-vscode",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chapel-vscode",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "vscode-languageclient": "^8.0.2"

--- a/package.json
+++ b/package.json
@@ -82,13 +82,8 @@
     ],
     "commands": [
       {
-        "command": "chapel.findChpl",
-        "title": "Find Chapel",
-        "category": "chapel"
-      },
-      {
-        "command": "chapel.buildTools",
-        "title": "Build chpl-language-server and chplcheck",
+        "command": "chapel.findChplHome",
+        "title": "Find CHPL_HOME",
         "category": "chapel"
       },
       {
@@ -114,7 +109,7 @@
           "chapel.CHPL_HOME": {
             "scope": "window",
             "type": "string",
-            "description": "CHPL_HOME"
+            "description": "The path to CHPL_HOME. If not provided, the extension may be able to find it automatically if `chpl`, `chplcheck`, and `chpl-language-server` are in PATH."
           },
           "chapel.CHPL_DEVELOPER": {
             "scope": "window",
@@ -127,6 +122,11 @@
             "type": "boolean",
             "default": true,
             "description": "Enable chplcheck"
+          },
+          "chapel.chplcheck.path": {
+            "scope": "window",
+            "type": "string",
+            "description": "An explicit path to the chplcheck executable. If not provided, the extension will look for chplcheck in PATH and in CHPL_HOME"
           },
           "chapel.chplcheck.args": {
             "scope": "window",
@@ -142,6 +142,11 @@
             "type": "boolean",
             "default": true,
             "description": "Enable chpl-language-server"
+          },
+          "chapel.chpl-language-server.path": {
+            "scope": "window",
+            "type": "string",
+            "description": "An explicit path to the chpl-language-server executable. If not provided, the extension will look for chpl-language-server in PATH and in CHPL_HOME"
           },
           "chapel.chpl-language-server.resolver": {
             "scope": "window",

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -184,24 +184,6 @@ export function cloneEnv() {
   return env;
 }
 
-// export function buildTools(chplhome: string) {
-//   let env = cloneEnv();
-//   const term = vscode.window.createTerminal({ cwd: chplhome, env: env });
-//   term.sendText(`make chpl-language-server || exit 1 && make chplcheck || exit 1 && exit 0`);
-//   term.show();
-//   vscode.window.onDidChangeTerminalState((e) => {
-//     if (e === term && e.exitStatus !== undefined) {
-//       if (e.exitStatus.code === 0) {
-//         vscode.window.showInformationMessage("Build complete");
-//         vscode.commands.executeCommand("chplcheck.restart");
-//         vscode.commands.executeCommand("chpl-language-server.restart");
-//       } else {
-//         vscode.window.showWarningMessage(`Build failed, try running 'export CHPL_HOME=${chplhome} && make chpl-language-server && make chplcheck' in the CHPL_HOME directory to see the error message.`);
-//       }
-//     }
-//   })
-// }
-
 export function getWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
   const editor = vscode.window.activeTextEditor;
   if (editor === undefined) {

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -81,6 +81,9 @@ function searchPATH(file: string, callback: (file_path: string) => boolean | voi
 }
 
 export function checkToolPath(tool_path: string): string | undefined {
+  if (tool_path === "") {
+    return "Path is empty";
+  }
   if (!fs.existsSync(tool_path) || !fs.statSync(tool_path).isFile()) {
     return `${tool_path} does not exist`;
   }

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -28,12 +28,12 @@ export function checkChplHome(
     return "CHPL_HOME is not set";
   }
 
-  if (!path.isAbsolute(chplhome)) {
-    return `CHPL_HOME (${chplhome}) is not an absolute path`;
-  }
-
   if (!fs.existsSync(chplhome) || !fs.statSync(chplhome).isDirectory()) {
     return `CHPL_HOME (${chplhome}) does not exist`;
+  }
+
+  if (!path.isAbsolute(chplhome)) {
+    return `CHPL_HOME (${chplhome}) is not an absolute path`;
   }
 
   const subdirs = [
@@ -75,6 +75,12 @@ function searchDirectoryForChplHome(dir: string, depth: number = 1): string[] {
     if (checkChplHome(dir) === undefined) {
       chplhomes.push(dir);
     } else if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
+      try {
+        // sadly this is the only way synchronous way to check if the directory is readable
+        fs.accessSync(dir, fs.constants.R_OK);
+      } catch(err) {
+        return chplhomes;
+      }
       fs.readdirSync(dir).forEach((subdir) => {
         const subdir_path = path.join(dir, subdir);
         chplhomes.push(...searchDirectoryForChplHome(subdir_path, depth - 1));

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -21,6 +21,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as vscode from "vscode";
 import * as cfg from "./configuration";
+import { showInvalidPathWarning } from "./extension";
 import assert from "assert";
 
 export function checkChplHome(
@@ -66,7 +67,10 @@ export function checkChplHome(
 
 // take a callback to be called on each file found
 // if the callback returns true, stop searching
-function searchPATH(file: string, callback: (file_path: string) => boolean | void) {
+function searchPATH(
+  file: string,
+  callback: (file_path: string) => boolean | void
+) {
   const PATH = process.env["PATH"];
   const paths_to_check = PATH?.split(path.delimiter) ?? [];
   for (const p of paths_to_check) {
@@ -100,12 +104,12 @@ export function findToolPath(
   // 2. if there is a chplhome, use that
   // 3. otherwise, search PATH
 
-  const cfg_tool_path = tool_name === "chplcheck" ? cfg.getChplCheckConfig().path : cfg.getCLSConfig().path;
-  if (cfg_tool_path !== undefined) {
-    const error = checkToolPath(cfg_tool_path);
-    if (error === undefined) {
-      return cfg_tool_path;
-    }
+  const cfg_tool_path =
+    tool_name === "chplcheck"
+      ? cfg.getChplCheckConfig().path
+      : cfg.getCLSConfig().path;
+  if (cfg_tool_path !== undefined && cfg_tool_path !== "") {
+    return cfg_tool_path;
   }
 
   if (chplhome !== undefined && checkChplHome(chplhome) === undefined) {
@@ -133,7 +137,7 @@ function searchDirectoryForChplHome(dir: string, depth: number = 1): string[] {
       try {
         // sadly this is the only way synchronous way to check if the directory is readable
         fs.accessSync(dir, fs.constants.R_OK);
-      } catch(err) {
+      } catch (err) {
         return chplhomes;
       }
       fs.readdirSync(dir).forEach((subdir) => {

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -97,7 +97,7 @@ export function findPossibleChplHomes(): string[] {
 
   // as a best effort, we find chpl in the PATH and check if chplhome is the parent directory
   const PATH = process.env["PATH"];
-  const paths_to_check = PATH?.split(":") ?? [];
+  const paths_to_check = PATH?.split(path.delimiter) ?? [];
   for (const p of paths_to_check) {
     const chpl_path = path.join(p, "chpl");
     if (fs.existsSync(chpl_path) && fs.statSync(chpl_path).isFile()) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -43,7 +43,12 @@ export function getChplHome(): string {
 export function setChplHome(chplhome: string) {
   const config = vscode.workspace.getConfiguration(configScope);
 
-  // when updating CHPL_HOME, we should update the workspace config if its been overriden, otherwise set it globally for all users
+  // an unfortunate aspect of the vscode API is that it doesn't allow us to
+  // distinguish between global local and global remote settings. This means
+  // this code may edit the wrong config file, because it will prefer the
+  // global local settings over the global remote settings. This is a known
+  // issue with the vscode API:
+  // https://github.com/microsoft/vscode/issues/182696
   if(config.inspect("CHPL_HOME")?.workspaceValue !== undefined) {
     config.update("CHPL_HOME", chplhome, vscode.ConfigurationTarget.Workspace);
   } else {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,8 +22,9 @@ import * as vscode from "vscode";
 export interface ToolConfig {
   args: Array<string>;
   enable: boolean;
+  path: string | undefined;
 }
-const ToolConfigDefault: ToolConfig = {args: [], enable: false};
+const ToolConfigDefault: ToolConfig = {args: [], enable: false, path: undefined};
 
 export type ChplCheckConfig = ToolConfig;
 const ChplCheckConfigDefault: ChplCheckConfig = {...ToolConfigDefault };
@@ -35,10 +36,10 @@ const CLSConfigDefault: CLSConfig = {...ToolConfigDefault, resolver: false};
 
 const configScope = "chapel";
 
-export function getChplHome(): string {
+export function getChplHome(): string | undefined {
   const config = vscode.workspace.getConfiguration(configScope);
   const chplhome = config.get<string>("CHPL_HOME");
-  return chplhome ?? "";
+  return chplhome ?? undefined;
 }
 export function setChplHome(chplhome: string) {
   const config = vscode.workspace.getConfiguration(configScope);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -24,15 +24,19 @@ export interface ToolConfig {
   enable: boolean;
   path: string | undefined;
 }
-const ToolConfigDefault: ToolConfig = {args: [], enable: false, path: undefined};
+const ToolConfigDefault: ToolConfig = {
+  args: [],
+  enable: false,
+  path: undefined,
+};
 
 export type ChplCheckConfig = ToolConfig;
-const ChplCheckConfigDefault: ChplCheckConfig = {...ToolConfigDefault };
+const ChplCheckConfigDefault: ChplCheckConfig = { ...ToolConfigDefault };
 
 export interface CLSConfig extends ToolConfig {
   resolver: boolean;
 }
-const CLSConfigDefault: CLSConfig = {...ToolConfigDefault, resolver: false};
+const CLSConfigDefault: CLSConfig = { ...ToolConfigDefault, resolver: false };
 
 const configScope = "chapel";
 
@@ -50,7 +54,7 @@ export function setChplHome(chplhome: string) {
   // global local settings over the global remote settings. This is a known
   // issue with the vscode API:
   // https://github.com/microsoft/vscode/issues/182696
-  if(config.inspect("CHPL_HOME")?.workspaceValue !== undefined) {
+  if (config.inspect("CHPL_HOME")?.workspaceValue !== undefined) {
     config.update("CHPL_HOME", chplhome, vscode.ConfigurationTarget.Workspace);
   } else {
     config.update("CHPL_HOME", chplhome, vscode.ConfigurationTarget.Global);
@@ -64,7 +68,8 @@ export function getChplDeveloper(): boolean {
 
 export function getChplCheckConfig(): ChplCheckConfig {
   const config = vscode.workspace.getConfiguration(configScope);
-  const chplcheck = config.get<ChplCheckConfig>("chplcheck") ?? ChplCheckConfigDefault;
+  const chplcheck =
+    config.get<ChplCheckConfig>("chplcheck") ?? ChplCheckConfigDefault;
   return chplcheck;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,27 @@ let chplcheckClient: ChplCheckClient;
 let clsClient: CLSClient;
 let logger: vscode.LogOutputChannel;
 
+export function showInvalidPathWarning(
+  tool: string,
+  path: string,
+  errorString?: string
+) {
+  if (errorString) {
+    logger.warn(errorString);
+  }
+
+  let msg = `The path '${path}' for ${tool} is invalid, errors may occur. Please double check that this is the correct path.`;
+  if (path === "") {
+    msg = `The path for ${tool} is not set, errors may occur. Please either set the path or remove the empty path.`;
+  }
+
+  vscode.window.showWarningMessage(msg, "Show Log", "Ok").then((value) => {
+    if (value === "Show Log") {
+      logger.show();
+    }
+  });
+}
+
 export function showChplHomeMissingError(errorString?: string) {
   if (errorString) {
     logger.error(errorString);
@@ -54,7 +75,8 @@ export function showChplHomeMissingError(errorString?: string) {
 function pickMyOwnChplHome() {
   vscode.window
     .showInputBox({
-      placeHolder: "Enter the path to CHPL_HOME (possibly run `chpl --print-chpl-home` in the terminal to find it)",
+      placeHolder:
+        "Enter the path to CHPL_HOME (possibly run `chpl --print-chpl-home` in the terminal to find it)",
     })
     .then((selection) => {
       if (selection !== undefined) {
@@ -100,11 +122,7 @@ export function activate(context: vscode.ExtensionContext) {
     "chplcheck",
     logger
   );
-  clsClient = new CLSClient(
-    getCLSConfig(),
-    "chpl-language-server",
-    logger
-  );
+  clsClient = new CLSClient(getCLSConfig(), "chpl-language-server", logger);
 
   // Restart language server command
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,23 +94,6 @@ export function activate(context: vscode.ExtensionContext) {
       }
     })
   );
-  // context.subscriptions.push(
-  //   vscode.commands.registerCommand(
-  //     "chapel.buildTools",
-  //     async (chplhome?: string) => {
-  //       if (chplhome === undefined) {
-  //         chplhome = getChplHome();
-  //       }
-  //       if (checkChplHome(chplhome) === undefined) {
-  //         buildTools(chplhome);
-  //       } else {
-  //         vscode.window.showWarningMessage(
-  //           `Unable to build automatically, please build manually`
-  //         );
-  //       }
-  //     }
-  //   )
-  // );
 
   chplcheckClient = new ChplCheckClient(
     getChplCheckConfig(),

--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -129,11 +129,15 @@
     "string_format": {
       "patterns": [
         {
-          "match": "%%",
+          "match": "(%[{]([#]+|[#]*[.][#]+)[}])",
           "name": "constant.other.placeholder.chapel"
         },
         {
-          "match": "%[0-9]+\\.[0-9]*(i|di|u|du|bi|bu||@bu|oi|ou)",
+          "match": "(%(@|\\+|0|<|>|\\^)*(\\*|[0-9]+)?(\\.[0-9]*)?[dxXobjh'\"]?[eE]?([niurmzsSc]|([{](.S|\\*S|.S.)[}])|(/.*/)|([{]/.*/[a-zA-Z]+[}]))?)",
+          "name": "constant.other.placeholder.chapel"
+        },
+        {
+          "match": "(%%)",
           "name": "constant.other.placeholder.chapel"
         }
       ]

--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -57,7 +57,7 @@
           "name": "keyword.operator.assignment.augmented.chapel"
         },
         {
-          "match": "\\+|-|\\*|\\*\\*|/|%|<<|>>|&|(\\|)|\\^|~|<=>|\\.\\.<|\\.\\.#|\\.\\.\\.|\\.\\.",
+          "match": "\\+|-|\\*|\\*\\*|/|%|<<|>>|&|(\\|)|\\^|~|<=>|\\.\\.<|#|\\.\\.\\.|\\.\\.",
           "name": "keyword.operator.arithmetic.chapel"
         },
         {

--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -80,20 +80,58 @@
           "match": "\\b(true|false|nil)\\b",
           "name": "constant.language.chapel"
         },
+        { "include": "#integers" },
+        { "include": "#floats" }
+      ]
+    },
+    "integers": {
+      "patterns": [
         {
-          "match": "\\b([0-9][0-9_]*)\\b",
+          "match": "\\b([0-9][0-9_]*)i?\\b",
           "name": "constant.numeric.chapel"
         },
         {
-          "match": "\\b(0[xX][0-9a-fA-F][0-9a-fA-F_]*)\\b",
+          "match": "\\b(0[xX][0-9a-fA-F][0-9a-fA-F_]*)i?\\b",
           "name": "constant.numeric.chapel"
         },
         {
-          "match": "\\b(0[bB][01][01_]*)\\b",
+          "match": "\\b(0[bB][01][01_]*)i?\\b",
           "name": "constant.numeric.chapel"
         },
         {
-          "match": "\\b(0[oO][0-7][0-7_]*)\\b",
+          "match": "\\b(0[oO][0-7][0-7_]*)i?\\b",
+          "name": "constant.numeric.chapel"
+        }
+      ]
+    },
+    "floats": {
+      "patterns": [
+        {
+          "match": "\\.([0-9][0-9_]*)([Ee](\\+|-)?([0-9][0-9_]*))?i?\\b",
+          "name": "constant.numeric.chapel"
+        },
+        {
+          "match": "\\b([0-9][0-9_]*)\\.([0-9][0-9_]*)([Ee](\\+|-)?([0-9][0-9_]*))?i?\\b",
+          "name": "constant.numeric.chapel"
+        },
+        {
+          "match": "\\b([0-9][0-9_]*)\\.([Ee](\\+|-)?([0-9][0-9_]*))i?\\b",
+          "name": "constant.numeric.chapel"
+        },
+        {
+          "match": "\\b([0-9][0-9_]*)([Ee](\\+|-)?([0-9][0-9_]*))i?\\b",
+          "name": "constant.numeric.chapel"
+        },
+        {
+          "match": "\\b0[xX]([0-9a-fA-F][0-9a-fA-F_]*)?\\.([0-9a-fA-F][0-9a-fA-F_]*)([Pp](\\+|-)?([0-9a-fA-F][0-9a-fA-F_]*))?i?\\b",
+          "name": "constant.numeric.chapel"
+        },
+        {
+          "match": "\\b0[xX]([0-9a-fA-F][0-9a-fA-F_]*)\\.([Pp](\\+|-)?([0-9a-fA-F][0-9a-fA-F_]*))i?\\b",
+          "name": "constant.numeric.chapel"
+        },
+        {
+          "match": "\\b0[xX]([0-9a-fA-F][0-9a-fA-F_]*)([Pp](\\+|-)?([0-9a-fA-F][0-9a-fA-F_]*))i?\\b",
           "name": "constant.numeric.chapel"
         }
       ]


### PR DESCRIPTION
This PR bundles a number of fixes and improves to the extension

Features
- The extension is no longer reliant on a `CHPL_HOME` value
- Can detect and use prefix-based installs
- Added better error detection and handling
  - When CLS/chplcheck has crashed, the status bar now also has a notification to show that these are not working correctly. 
- Removed the ability to build the tools automatically, this was error prone and only rarely the "correct" course of action
- Syntax highlighting for format string specifiers

List of fixes
- Resolve issues with searching PATH
- Fix syntax highlighting for numbers and the count operator

Tested locally with two versions of a chapel, a CHPL_HOME build from source and with a prefix install from homebrew

[Reviewed by @ShreyasKhandekar]