### PR TITLE
Fix syntax highlight bug with %'S and %"S

### DIFF
--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -171,7 +171,7 @@
           "name": "constant.other.placeholder.chapel"
         },
         {
-          "match": "(%(@|\\+|0|<|>|\\^)*(\\*|[0-9]+)?(\\.[0-9]*)?[dxXobjh'\"]?[eE]?([niurmzsSc]|([{](.S|\\*S|.S.)[}])|(/.*/)|([{]/.*/[a-zA-Z]+[}]))?)",
+          "match": "(%(@|\\+|0|<|>|\\^)*(\\*|[0-9]+)?(\\.[0-9]*)?(?:[dxXobjh]|(?:[\\\\]?['\"][S]))?[eE]?([niurmzsSc]|([{](.S|\\*S|.S.)[}])|(/.*/)|([{]/.*/[a-zA-Z]+[}]))?)",
           "name": "constant.other.placeholder.chapel"
         },
         {


### PR DESCRIPTION
Fixes an issue where the string `'%'` would be incorrectly highlighted and cause all subsequent text to be miss-highlighted

Reviewed by @ShreyasKhandekar