### PR TITLE
Make sure %? is syntax highlighted

### DIFF
--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -167,6 +167,10 @@
     "string_format": {
       "patterns": [
         {
+          "match": "(%\\?)",
+          "name": "constant.other.placeholder.chapel"
+        },
+        {
           "match": "(%[{]([#]+|[#]*[.][#]+)[}])",
           "name": "constant.other.placeholder.chapel"
         },


### PR DESCRIPTION
Ensure that `%?` is properly syntax highlighted

Before:
<img width="326" alt="Screenshot 2024-10-15 at 2 19 07 PM" src="https://github.com/user-attachments/assets/ae236cc9-fe35-419c-a589-b16dfec93270">
After:
<img width="296" alt="Screenshot 2024-10-15 at 2 18 58 PM" src="https://github.com/user-attachments/assets/c5fb65c4-fbc2-42d6-9e9b-f54b37a74bf6">
