### PR TITLE
Add missing keywords to syntax highlighting

### DIFF
--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -77,7 +77,7 @@
     "constants": {
       "patterns": [
         {
-          "match": "\\b(true|false|nil)\\b",
+          "match": "\\b(true|false|nil|none)\\b",
           "name": "constant.language.chapel"
         },
         { "include": "#integers" },

--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -29,7 +29,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|deinit|continue|defer|delete|dmapped|do|else|enum|except|export|extern|for|forall|foreach|forwarding|if|import|in|index|init|init=|inline|inout|interface|implements|iter|label|lambda|let|lifetime|local|manage|module|new|noinit|on|only|operator|otherwise|out|override|postinit|__primitive|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|shared|then|these|throw|throws|try|union|use|when|where|while|with|yield|zip)\\b",
+          "match": "\\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|deinit|continue|defer|delete|dmapped|do|else|enum|except|export|extern|for|forall|foreach|forwarding|if|import|in|include|index|init|init=|inline|inout|interface|implements|iter|label|lambda|let|lifetime|local|manage|module|new|noinit|on|only|operator|otherwise|out|override|postinit|__primitive|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|shared|then|these|throw|throws|try|union|use|when|where|while|with|yield|zip)\\b",
           "name": "keyword.control.chapel"
         },
         {

--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -29,7 +29,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|deinit|continue|defer|delete|dmapped|do|else|enum|except|export|extern|for|forall|foreach|forwarding|if|import|in|include|index|init|init=|inline|inout|interface|implements|iter|label|lambda|let|lifetime|local|manage|module|new|noinit|on|only|operator|otherwise|out|override|postinit|__primitive|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|shared|then|these|throw|throws|try|union|use|when|where|while|with|yield|zip)\\b",
+          "match": "\\b(align|as|atomic|begin|break|by|catch|class|cobegin|coforall|deinit|continue|defer|delete|dmapped|do|else|enum|except|export|extern|for|forall|foreach|forwarding|if|import|in|include|index|init|init=|inline|inout|interface|implements|iter|label|lambda|let|lifetime|local|manage|module|new|noinit|on|only|operator|otherwise|out|override|postinit|__primitive|pragma|private|proc|prototype|public|record|reduce|require|return|scan|select|serial|then|these|throw|throws|try|union|use|when|where|while|with|yield|zip)\\b",
           "name": "keyword.control.chapel"
         },
         {
@@ -41,7 +41,7 @@
           "name": "storage.type.chapel"
         },
         {
-          "match": "\\b(borrowed|config|const|owned|param|private|public|ref|sync|single|sparse|sync|type|unmanaged|var)\\b",
+          "match": "\\b(borrowed|config|const|owned|param|private|public|ref|shared|single|sparse|sync|type|unmanaged|var)\\b",
           "name": "storage.modifier.chapel"
         }
       ]


### PR DESCRIPTION
Adds missing keywords 'none' and 'include' to the syntax highlighter.

Also fixed `shared` being shown as a keyword, not a type modifier