### PR TITLE
Fix checkChplHome for prefix-based installs

### DIFF
--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -42,7 +42,6 @@ export function checkChplHome(
   const subdirs = [
     "util",
     "compiler",
-    "frontend",
     "runtime",
     "modules",
     "tools",


### PR DESCRIPTION
Fixes the logic in checkChplHome for prefix-based installs. This checks for a valid CHPL_HOME directory, however `frontend` does not exist in a prefix-installed CHPL_HOME.