### PR TITLE
Add ability to generate debug configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,8 +96,13 @@
         "category": "chapel"
       },
       {
-        "command": "chapel.generateGenericDebug",
-        "title": "Generate a launch.json for a Chapel program",
+        "command": "chapel.createDebugConfig",
+        "title": "Create a debug launch.json for Chapel",
+        "category": "chapel"
+      },
+      {
+        "command": "chapel.createDebugConfigForActiveFile",
+        "title": "Create a debug launch.json for the active Chapel file",
         "category": "chapel"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "keywords": [
     "chapel"
   ],
-  "activationEvents": [],
   "main": "./out/extension.js",
   "icon": "./icons/chapel.png",
   "license": "SEE LICENSE IN LICENSE",
@@ -95,6 +94,11 @@
         "command": "chpl-language-server.restart",
         "title": "Restart chpl-language-server",
         "category": "chapel"
+      },
+      {
+        "command": "chapel.generateGenericDebug",
+        "title": "Generate a launch.json for a Chapel program",
+        "category": "chapel"
       }
     ],
     "activationEvents": [
@@ -161,6 +165,15 @@
               "type": "string"
             },
             "description": "Extra arguments to pass to chpl-language-server"
+          },
+          "chapel.preferredDebugProvider": {
+            "scope": "window",
+            "type": "string",
+            "description": "The preferred debug provider to use",
+            "enum": [
+              "vadimcn.vscode-lldb"
+            ],
+            "default": "vadimcn.vscode-lldb"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -202,9 +202,9 @@
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "@vscode/test-electron": "^2.3.6",
+    "@vscode/vsce": "^3.3.2",
     "eslint": "^8.52.0",
-    "typescript": "^5.2.2",
-    "@vscode/vsce": "^3.3.2"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "vscode-languageclient": "^8.0.2"

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -227,7 +227,7 @@ export function getEnvAffectingChapel(): Map<string, string> {
 
   // special handling for CHPL_HOME and CHPL_DEVELOPER
   const chplhome = cfg.getChplHome();
-  if (chplhome != undefined || chplhome !== "") {
+  if (chplhome != undefined && chplhome !== "") {
     env.set("CHPL_HOME", chplhome);
   } else if (process.env["CHPL_HOME"] !== undefined) {
     env.set("CHPL_HOME", process.env["CHPL_HOME"]);

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -196,6 +196,10 @@ export function getWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
   return vscode.workspace.getWorkspaceFolder(doc.uri);
 }
 
+/*
+  Gets all of the environment variables that could possibly affect Chapel
+  execution. This can be used to prepopulated configuration files for users or\to forward on the custom sub-processes.
+*/
 export function getEnvAffectingChapel(): Map<string, string> {
   const globs = [
     "CHPL_.*",

--- a/src/ChplPaths.ts
+++ b/src/ChplPaths.ts
@@ -195,3 +195,50 @@ export function getWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
   const doc = editor.document;
   return vscode.workspace.getWorkspaceFolder(doc.uri);
 }
+
+export function getEnvAffectingChapel(): Map<string, string> {
+  const globs = [
+    "CHPL_.*",
+    "CHPL_RT_.*",
+    "FI_.*",
+    "GASNET_.*",
+    "SLURM_.*",
+    "PBS_.*",
+    "QTHREAD_.*",
+    "QT_.*",
+    "ASAN_OPTIONS",
+  ];
+  // TODO: consider including?
+  // PKG_CONFIG_PATH
+  // HUGETLB_NO_RESERVE
+  // MASON_REGISTRY
+  // SPACK_ROOT
+  // PYTHON*
+  // LD_LIBRARY_PATH
+  // DYLD_LIBRARY_PATH
+  const regex = new RegExp(`^(${globs.join('|')})$`)
+
+  let env = new Map();
+  for (const e in process.env) {
+    if (regex.test(e)) {
+      env.set(e, process.env[e] ?? "");
+    }
+  }
+
+  // special handling for CHPL_HOME and CHPL_DEVELOPER
+  const chplhome = cfg.getChplHome();
+  if (chplhome != undefined || chplhome !== "") {
+    env.set("CHPL_HOME", chplhome);
+  } else if (process.env["CHPL_HOME"] !== undefined) {
+    env.set("CHPL_HOME", process.env["CHPL_HOME"]);
+  }
+  const chpldev = cfg.getChplDeveloper();
+  if (chpldev !== undefined && chpldev) {
+    env.set("CHPL_DEVELOPER", "1");
+  } else if (process.env["CHPL_DEVELOPER"] !== undefined) {
+    env.set("CHPL_DEVELOPER", process.env["CHPL_DEVELOPER"]);
+  }
+
+  return env;
+
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -78,3 +78,9 @@ export function getCLSConfig(): CLSConfig {
   const cls = config.get<CLSConfig>("chpl-language-server") ?? CLSConfigDefault;
   return cls;
 }
+
+export function getPreferredDebugProvider(): string | undefined {
+  const config = vscode.workspace.getConfiguration(configScope);
+  const provider = config.get<string>("preferredDebugProvider");
+  return provider ?? undefined;
+}

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -24,56 +24,113 @@ import { getPreferredDebugProvider } from './configuration';
 export function registerDebugCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
-      "chapel.generateGenericDebug",
-      async () => {
-        // determine the provider
-        const provider = getPreferredProvider();
-        if (!provider) {
-          const preferredProviderId = getPreferredDebugProvider();
-          vscode.window.showErrorMessage(`The requested debug provider ${preferredProviderId} is not installed/supported`);
-          return;
-        }
-
-        if (!provider.isAvailable()) {
-          vscode.window.showErrorMessage(`The requested debug provider ${provider.id} is not installed. Please install [${provider.name}](command:${provider.getInstallCommand()}) or select another provider.`);
-          return;
-        }
-
-        // TODO: we could do some kind of detection for mason projects, maybe even Make/CMake?
-        // TODO: for the executables, we could search for all executable files?
-        // TODO create a custom webview to let the user select the executable and env vars and args
-        // for now, prompt the user for a name and a path the executable
-
-        const name = await vscode.window.showInputBox({ placeHolder: "Enter the name of the debug configuration" });
-        if (!name) {
-          return;
-        }
-        const executable = await vscode.window.showInputBox({ placeHolder: "Enter the path to the executable" });
-        if (!executable) {
-          return;
-        }
-
-        const newConfig = provider.createDebugConfig(name, executable);
-
-        const launchConfigs = vscode.workspace.getConfiguration("launch");
-        const configs = launchConfigs.get<any[]>("configurations") || [];
-        const existingConfigIdx = configs.findIndex((config: any) => config.name === name);
-        if (existingConfigIdx !== -1) {
-          const choice = await vscode.window.showErrorMessage(`A debug configuration with the name ${name} already exists.`, "Cancel", "Overwrite");
-          if (choice !== "Cancel") {
-            configs[existingConfigIdx] = newConfig;
-          }
-        } else {
-          configs.push(newConfig);
-        }
-        launchConfigs.update("configurations", configs).then(() => {
-          vscode.window.showInformationMessage(`Debug configuration ${name} created successfully.`);
-        }, (err) => {
-          vscode.window.showErrorMessage(`Failed to create debug configuration: ${err}`);
-        });
-      }
+      "chapel.createDebugConfig",
+      chapel_createDebugConfig
     )
   );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "chapel.createDebugConfigForActiveFile",
+      chapel_createDebugConfigForActiveFile
+    )
+  );
+}
+async function chapel_createDebugConfig() {
+  const provider = getProvider();
+  if (!provider) {
+    return
+  }
+  // TODO: we could do some kind of detection for mason projects, maybe even Make/CMake?
+  // TODO: for the executables, we could search for all executable files?
+  // TODO create a custom webview to let the user select the executable and env vars and args
+  // for now, prompt the user for a name and a path the executable
+
+  const name = await vscode.window.showInputBox({ placeHolder: "Enter the name of the debug configuration" });
+  if (!name) {
+    return;
+  }
+  const executable = await vscode.window.showInputBox({ placeHolder: "Enter the path to the executable" });
+  if (!executable) {
+    return;
+  }
+
+  const newConfig = provider.createDebugConfig(name, executable);
+  await saveConfig(newConfig);
+}
+
+async function chapel_createDebugConfigForActiveFile() {
+  const provider = getProvider();
+  if (!provider) {
+    return
+  }
+
+  // get the current file
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showErrorMessage("No active editor found.");
+    return;
+  }
+  const document = editor.document;
+  if (document.languageId !== "chapel") {
+    vscode.window.showErrorMessage("The current file is not a Chapel file.");
+    return;
+  }
+  const executablePath = document.fileName?.split(".").slice(0, -1).join(".");
+  if (!executablePath) {
+    vscode.window.showErrorMessage("Failed to get the file name.");
+    return;
+  }
+  const wsPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (!wsPath) {
+    vscode.window.showErrorMessage("No workspace folder found.");
+  }
+  let executableNiceName: string = executablePath.split("/").pop() || executablePath;
+  let executableRelPath: string = executablePath;
+  if (wsPath) {
+    // determine executableRelPath to wsPath
+    executableNiceName = executablePath.replace(wsPath + "/", "");
+    executableRelPath = "${workspaceFolder}/" + executableNiceName;
+  }
+
+  const newConfig = provider.createDebugConfig(`Debug ${executableNiceName}`, executableRelPath);
+  await saveConfig(newConfig);
+}
+
+
+function getProvider(): DebugProvider | undefined {
+  // determine the provider
+  const provider = getPreferredProvider();
+  if (!provider) {
+    const preferredProviderId = getPreferredDebugProvider();
+    vscode.window.showErrorMessage(`The requested debug provider '${preferredProviderId}' is not installed/supported`);
+    return;
+  }
+
+  if (!provider.isAvailable()) {
+    vscode.window.showErrorMessage(`The requested debug provider '${provider.id}' is not installed. Please install [${provider.name}](command:${provider.getInstallCommand()}) or select another provider.`);
+    return;
+  }
+  return provider;
+}
+
+async function saveConfig(newConfig: vscode.DebugConfiguration) {
+  const name = newConfig.name;
+  const launchConfigs = vscode.workspace.getConfiguration("launch");
+  const configs = launchConfigs.get<any[]>("configurations") || [];
+  const existingConfigIdx = configs.findIndex((config: any) => config.name === name);
+  if (existingConfigIdx !== -1) {
+    const choice = await vscode.window.showErrorMessage(`A debug configuration named '${name}' already exists.`, "Cancel", "Overwrite");
+    if (choice !== "Cancel") {
+      configs[existingConfigIdx] = newConfig;
+    }
+  } else {
+    configs.push(newConfig);
+  }
+  launchConfigs.update("configurations", configs).then(() => {
+    vscode.window.showInformationMessage(`Debug configuration '${name}' created successfully.`);
+  }, (err) => {
+    vscode.window.showErrorMessage(`Failed to create debug configuration: ${err}`);
+  });
 }
 
 class DebugProvider {

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -20,6 +20,7 @@
 
 import * as vscode from 'vscode';
 import { getPreferredDebugProvider } from './configuration';
+import { getEnvAffectingChapel } from './ChplPaths';
 
 export function registerDebugCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -152,6 +153,15 @@ async function getArgsAndEnv() {
       }
     }
   }
+
+  const baseEnv = getEnvAffectingChapel();
+  // merge the base env with the user provided env, prefer user provided env
+  for (const [key, value] of baseEnv) {
+    if (!envMap.has(key)) {
+      envMap.set(key, value);
+    }
+  }
+
   return { argsArray, envMap };
 }
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024-2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import * as vscode from 'vscode';
+import { getPreferredDebugProvider } from './configuration';
+
+export function registerDebugCommands(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "chapel.generateGenericDebug",
+      async () => {
+        // determine the provider
+        const provider = getPreferredProvider();
+        if (!provider) {
+          const preferredProviderId = getPreferredDebugProvider();
+          vscode.window.showErrorMessage(`The requested debug provider ${preferredProviderId} is not installed/supported`);
+          return;
+        }
+
+        if (!provider.isAvailable()) {
+          vscode.window.showErrorMessage(`The requested debug provider ${provider.id} is not installed. Please install [${provider.name}](command:${provider.getInstallCommand()}) or select another provider.`);
+          return;
+        }
+
+        // TODO: we could do some kind of detection for mason projects, maybe even Make/CMake?
+        // TODO: for the executables, we could search for all executable files?
+        // TODO create a custom webview to let the user select the executable and env vars and args
+        // for now, prompt the user for a name and a path the executable
+
+        const name = await vscode.window.showInputBox({ placeHolder: "Enter the name of the debug configuration" });
+        if (!name) {
+          return;
+        }
+        const executable = await vscode.window.showInputBox({ placeHolder: "Enter the path to the executable" });
+        if (!executable) {
+          return;
+        }
+
+        const newConfig = provider.createDebugConfig(name, executable);
+
+        const launchConfigs = vscode.workspace.getConfiguration("launch");
+        const configs = launchConfigs.get<any[]>("configurations") || [];
+        const existingConfigIdx = configs.findIndex((config: any) => config.name === name);
+        if (existingConfigIdx !== -1) {
+          const choice = await vscode.window.showErrorMessage(`A debug configuration with the name ${name} already exists.`, "Cancel", "Overwrite");
+          if (choice !== "Cancel") {
+            configs[existingConfigIdx] = newConfig;
+          }
+        } else {
+          configs.push(newConfig);
+        }
+        launchConfigs.update("configurations", configs).then(() => {
+          vscode.window.showInformationMessage(`Debug configuration ${name} created successfully.`);
+        }, (err) => {
+          vscode.window.showErrorMessage(`Failed to create debug configuration: ${err}`);
+        });
+      }
+    )
+  );
+}
+
+class DebugProvider {
+  name: string;
+  id: string;
+  type: string;
+  constructor(name: string, id: string, type: string) {
+    this.name = name;
+    this.id = id;
+    this.type = type;
+  }
+  getInstallCommand(): string {
+    return `extension.open?${encodeURIComponent(`"${this.id}"`)}`;
+  }
+  isAvailable(): boolean {
+    const extension = vscode.extensions.getExtension(this.id);
+    return extension !== undefined;
+  }
+  createDebugConfig(name: string, executable: string, args: string[] = [], env: Map<string, string> = new Map()): vscode.DebugConfiguration {
+    return {
+      name: name,
+      type: this.type,
+      request: "launch",
+      program: executable,
+      cwd: "${workspaceFolder}",
+      args: args,
+      env: Object.fromEntries(env),
+      sourceLanguages: ["chapel"],
+    };
+  }
+}
+
+const debugProviders: Map<string, DebugProvider> = new Map([
+  ["vadimcn.vscode-lldb", new DebugProvider("CodeLLDB", "vadimcn.vscode-lldb", "lldb")],
+])
+
+
+// currently unused
+function getAvailableProviders(): DebugProvider[] {
+  const availableProviders: DebugProvider[] = [];
+  for (const provider of debugProviders.values()) {
+    if (provider.isAvailable()) {
+      availableProviders.push(provider);
+    }
+  }
+  return availableProviders;
+}
+function getPreferredProvider(): DebugProvider | undefined {
+  const preferredProviderId = getPreferredDebugProvider();
+  if (preferredProviderId) {
+    const provider = debugProviders.get(preferredProviderId);
+    return provider;
+  }
+  return undefined;
+}
+
+
+// TODO: this is a placeholder for the webview panel
+// class LaunchConfigCreationPanel {
+// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
+// }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import {
 } from "./configuration";
 import { ChplCheckClient, CLSClient } from "./ChapelLanguageClient";
 import { checkChplHome, findPossibleChplHomes } from "./ChplPaths";
+import { registerDebugCommands } from "./debug";
 import * as fs from "fs";
 
 let chplcheckClient: ChplCheckClient;
@@ -117,6 +118,8 @@ export function activate(context: vscode.ExtensionContext) {
       }
     })
   );
+
+  registerDebugCommands(context);
 
   chplcheckClient = new ChplCheckClient(
     getChplCheckConfig(),


### PR DESCRIPTION
Adds 2 new commands to the extension which create debug configs for a user. This makes it easier to for users to get started debugging in VSCode.

- `createDebugConfig` will prompt the user to input some data about their executable
- `createDebugConfigForActiveFile` will generate a debug config based on some defaults

Future work will add native support for Mason projects and building Chapel programs