### PR TITLE
Add support for builtin in VSCode debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,9 +178,12 @@
             "description": "The preferred debug provider to use",
             "enum": [
               "vadimcn.vscode-lldb",
-              "cppdbg"
+              "ms-vscode.cpptools"
             ],
-            "default": "cppdbg"
+            "default": "ms-vscode.cpptools"
+          }
+
+
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -177,9 +177,10 @@
             "type": "string",
             "description": "The preferred debug provider to use",
             "enum": [
-              "vadimcn.vscode-lldb"
+              "vadimcn.vscode-lldb",
+              "cppdbg"
             ],
-            "default": "vadimcn.vscode-lldb"
+            "default": "cppdbg"
           }
         }
       }

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -108,7 +108,8 @@ function getProvider(): DebugProvider | undefined {
   }
 
   if (!provider.isAvailable()) {
-    vscode.window.showErrorMessage(`The requested debug provider '${provider.id}' is not installed. Please install [${provider.name}](command:${provider.getInstallCommand()}) or select another provider.`);
+    const getInstallCommand = provider.getInstallCommand as () => string;
+    vscode.window.showErrorMessage(`The requested debug provider '${provider.id}' is not installed. Please install [${provider.name}](command:${getInstallCommand()}) or select another provider.`);
     return;
   }
   return provider;
@@ -165,14 +166,23 @@ async function getArgsAndEnv() {
   return { argsArray, envMap };
 }
 
-class DebugProvider {
+interface DebugProvider {
   name: string;
   id: string;
   type: string;
-  constructor(name: string, id: string, type: string) {
-    this.name = name;
-    this.id = id;
-    this.type = type;
+  getInstallCommand?(): string;
+  isAvailable(): boolean;
+  createDebugConfig(name: string, executable: string, args?: string[], env?: Map<string, string>): vscode.DebugConfiguration;
+}
+
+class DebugProviderCodeLLDB implements DebugProvider {
+  name: string;
+  id: string;
+  type: string;
+  constructor() {
+    this.name = "CodeLLDB";
+    this.id = "vadimcn.vscode-lldb";
+    this.type = "lldb";
   }
   getInstallCommand(): string {
     return `extension.open?${encodeURIComponent(`"${this.id}"`)}`;
@@ -194,9 +204,39 @@ class DebugProvider {
     };
   }
 }
+class BuiltinDebugProvider implements DebugProvider {
+  name: string;
+  id: string;
+  type: string;
+  constructor() {
+    this.name = "Builtin Debugger";
+    this.id = "cppdbg";
+    this.type = "cppdbg";
+  }
+  isAvailable(): boolean { return true; }
+  createDebugConfig(name: string, executable: string, args: string[] = [], env: Map<string, string> = new Map()): vscode.DebugConfiguration {
+    return {
+      name: name,
+      type: this.type,
+      request: "launch",
+      program: executable,
+      cwd: "${workspaceFolder}",
+      args: args,
+      environment: [...Array.from(env.entries()).map(([key, value]) => ({ name: key, value: value }))],
+      stopAtEntry: false,
+      linux: {
+        MIMode: "gdb",
+      },
+      osx: {
+        MIMode: "lldb",
+      },
+    };
+  }
+}
 
 const debugProviders: Map<string, DebugProvider> = new Map([
-  ["vadimcn.vscode-lldb", new DebugProvider("CodeLLDB", "vadimcn.vscode-lldb", "lldb")],
+  ["vadimcn.vscode-lldb", new DebugProviderCodeLLDB()],
+  ["cppdbg", new BuiltinDebugProvider()],
 ])
 
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -203,16 +203,22 @@ class DebugProviderCodeLLDB implements DebugProvider {
     };
   }
 }
-class BuiltinDebugProvider implements DebugProvider {
+class CXXDebugProvider implements DebugProvider {
   name: string;
   id: string;
   type: string;
   constructor() {
-    this.name = "Builtin Debugger";
-    this.id = "cppdbg";
+    this.name = "C/C++ Debugger";
+    this.id = "ms-vscode.cpptools";
     this.type = "cppdbg";
   }
-  isAvailable(): boolean { return true; }
+  getInstallCommand(): string {
+    return `extension.open?${encodeURIComponent(`"${this.id}"`)}`;
+  }
+  isAvailable(): boolean {
+    const extension = vscode.extensions.getExtension(this.id);
+    return extension !== undefined;
+  }
   createDebugConfig(name: string, executable: string, args: string[] = [], env: Map<string, string> = new Map()): vscode.DebugConfiguration {
     return {
       name: name,
@@ -235,7 +241,7 @@ class BuiltinDebugProvider implements DebugProvider {
 
 const debugProviders: Map<string, DebugProvider> = new Map([
   ["vadimcn.vscode-lldb", new DebugProviderCodeLLDB()],
-  ["cppdbg", new BuiltinDebugProvider()],
+  ["ms-vscode.cpptools", new CXXDebugProvider()],
 ])
 
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -108,8 +108,7 @@ function getProvider(): DebugProvider | undefined {
   }
 
   if (!provider.isAvailable()) {
-    const getInstallCommand = provider.getInstallCommand as () => string;
-    vscode.window.showErrorMessage(`The requested debug provider '${provider.id}' is not installed. Please install [${provider.name}](command:${getInstallCommand()}) or select another provider.`);
+    vscode.window.showErrorMessage(`The requested debug provider '${provider.id}' is not installed. Please install [${provider.name}](command:${provider.getInstallCommand!()}) or select another provider.`);
     return;
   }
   return provider;


### PR DESCRIPTION
Adds support for the builtin VSCode debugger, and makes it the new default. While this debugger has less features, it is almost always available

Builds on the work done in https://github.com/chapel-lang/chapel-vscode/pull/30