### PR TITLE
Improve format string highlights

### DIFF
--- a/syntaxes/chapel.tmLanguage.json
+++ b/syntaxes/chapel.tmLanguage.json
@@ -171,7 +171,7 @@
           "name": "constant.other.placeholder.chapel"
         },
         {
-          "match": "(%[{]([#]+|[#]*[.][#]*)[}])",
+          "match": "(%[{]([#]+|[#]+[.][#]*|[#]*[.][#]+)[}])",
           "name": "constant.other.placeholder.chapel"
         },
         {


### PR DESCRIPTION
Improves the highlighting of format strings to include `%{?}`, `%{any format specifier}`, `%{##.}`