### PR TITLE
Reload CLS on addition of cls-commands.json

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,8 +163,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   const clsCommandWatcher = vscode.workspace.createFileSystemWatcher(
-    "**/.cls-commands.json",
-    false, false, true
+    "**/.cls-commands.json"
   );
   context.subscriptions.push(clsCommandWatcher);
   let clsRestartTimeout: ReturnType<typeof setTimeout> | undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,13 +144,20 @@ export function activate(context: vscode.ExtensionContext) {
       }
     )
   );
+  let configChangeTimeout: ReturnType<typeof setTimeout> | undefined;
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(async (e) => {
       if (e.affectsConfiguration("chapel")) {
-        Promise.all([
-          chplcheckClient.resetConfig(getChplCheckConfig()),
-          clsClient.resetConfig(getCLSConfig()),
-        ]);
+        if (configChangeTimeout !== undefined) {
+          clearTimeout(configChangeTimeout);
+        }
+        configChangeTimeout = setTimeout(async () => {
+          configChangeTimeout = undefined;
+          Promise.all([
+            chplcheckClient.resetConfig(getChplCheckConfig()),
+            clsClient.resetConfig(getCLSConfig()),
+          ]);
+        }, 5000);
       }
     })
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,6 +155,23 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  const clsCommandWatcher = vscode.workspace.createFileSystemWatcher(
+    "**/.cls-commands.json",
+    false, false, true
+  );
+  context.subscriptions.push(clsCommandWatcher);
+  let clsRestartTimeout: ReturnType<typeof setTimeout> | undefined;
+  clsCommandWatcher.onDidChange(async () => {
+    if (clsRestartTimeout !== undefined) {
+      clearTimeout(clsRestartTimeout);
+    }
+    clsRestartTimeout = setTimeout(async () => {
+      clsRestartTimeout = undefined;
+      await clsClient.stop();
+      await clsClient.start();
+    }, 5000);
+  });
+
   // Start the language server once the user opens the first text document
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument(async () => {


### PR DESCRIPTION
Add new cls-commands.json file watcher to reload CLS when the .cls-commands.json file is added/removed. This makes development smoother and doesn't require manual restarts.

I implemented this with a debounce logic, to prevent repeated writes to the file breaking the server. I applied this same logic back to the restart logic for when the vscode settings change