### PR TITLE
Improve Mason support within CLS

### DIFF
--- a/src/ChapelLanguageClient.ts
+++ b/src/ChapelLanguageClient.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { ToolConfig, getChplDeveloper, getChplHome } from "./configuration";
+import { ToolConfig, getBaseEnv, getChplDeveloper, getChplHome } from "./configuration";
 import * as fs from "fs";
 import * as vscode from "vscode";
 import * as vlc from "vscode-languageclient/node";
@@ -185,6 +185,25 @@ export abstract class ChapelLanguageClient {
 
   protected abstract alwaysArguments(): Array<string>;
 
+  envForConfig(): NodeJS.ProcessEnv {
+    let env = cloneEnv();
+    for (const [key, value] of getBaseEnv()) {
+      env[key] = value;
+    }
+    const chplhome = getChplHome();
+    if (chplhome !== undefined && chplhome !== "") {
+      this.logger.info(`Using CHPL_HOME: ${chplhome}`);
+      const chplHomeError = checkChplHome(chplhome);
+      if (chplHomeError !== undefined) {
+        showChplHomeMissingError(chplHomeError);
+      } else {
+        env.CHPL_HOME = chplhome;
+      }
+    }
+    env.CHPL_DEVELOPER = getChplDeveloper() ? "1" : "0";
+    return env;
+  }
+
   start(): Promise<void> {
     if (this.state !== LanguageClientState.STOPPED) {
       return Promise.resolve();
@@ -198,18 +217,7 @@ export abstract class ChapelLanguageClient {
       return Promise.reject();
     }
 
-    let env = cloneEnv();
-    const chplhome = getChplHome();
-    if (chplhome !== undefined && chplhome !== "") {
-      this.logger.info(`Using CHPL_HOME: ${chplhome}`);
-      const chplHomeError = checkChplHome(chplhome);
-      if (chplHomeError !== undefined) {
-        showChplHomeMissingError(chplHomeError);
-      } else {
-        env.CHPL_HOME = chplhome;
-      }
-    }
-    env.CHPL_DEVELOPER = getChplDeveloper() ? "1" : "0";
+    const env = this.envForConfig();
 
     let args = this.alwaysArguments();
     args.push(...this.config.args);

--- a/src/ChapelLanguageClient.ts
+++ b/src/ChapelLanguageClient.ts
@@ -18,6 +18,7 @@
  */
 
 import { ToolConfig, getBaseEnv, getChplDeveloper, getChplHome } from "./configuration";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as vscode from "vscode";
 import * as vlc from "vscode-languageclient/node";
@@ -28,9 +29,37 @@ import {
   findToolPath,
   findPossibleChplHomes,
   getWorkspaceFolder,
+  getDefaultMason,
 } from "./ChplPaths";
 import { showChplHomeMissingError } from "./extension";
 import * as path from "path";
+
+function getToolVersion(logger: vscode.LogOutputChannel, toolPath: string, env: NodeJS.ProcessEnv): string | undefined {
+  try {
+    const output = execFileSync(toolPath, ["--version"], {
+      timeout: 5000,
+      encoding: "utf-8",
+      env: env,
+    });
+    const match = output.match(/(\d+\.\d+\.\d+)/);
+    return match ? match[1] : undefined;
+  } catch (e) {
+    logger.error(`Failed to get version for tool at ${toolPath}: ${e}`);
+    return undefined;
+  }
+}
+
+function meetsMinVersion(version: string, minVersion: string): boolean {
+  const parts = version.split(".").map(Number);
+  const minParts = minVersion.split(".").map(Number);
+  for (let i = 0; i < Math.max(parts.length, minParts.length); i++) {
+    const a = parts[i] ?? 0;
+    const b = minParts[i] ?? 0;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return true;
+}
 
 export enum LanguageClientState {
   DISABLED,
@@ -353,7 +382,7 @@ export abstract class ChapelLanguageClient {
   stop(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.client && this.state === LanguageClientState.RUNNING) {
-        this.client.errorHandler = () => {};
+        this.client.errorHandler = () => { };
         this.client.stop().catch(reject);
         this.client.dispose();
         this.client = undefined;
@@ -398,6 +427,13 @@ export class CLSClient extends ChapelLanguageClient {
   }
   alwaysArguments(): Array<string> {
     let args = [];
+    const env = this.envForConfig();
+    const version = getToolVersion(this.logger, this.tool_path, env);
+    // log the version
+    this.logger.debug(`chpl-language-server version: ${version}`);
+    if (version && meetsMinVersion(version, "2.9.0")) {
+      args.push("--mason-path=" + getDefaultMason());
+    }
     if ("resolver" in this.config && this.config.resolver) {
       args.push("--resolver");
     }

--- a/src/ChapelLanguageClient.ts
+++ b/src/ChapelLanguageClient.ts
@@ -55,8 +55,8 @@ function meetsMinVersion(version: string, minVersion: string): boolean {
   for (let i = 0; i < Math.max(parts.length, minParts.length); i++) {
     const a = parts[i] ?? 0;
     const b = minParts[i] ?? 0;
-    if (a > b) return true;
-    if (a < b) return false;
+    if (a > b) { return true; };
+    if (a < b) { return false; };
   }
   return true;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,15 +144,19 @@ export function activate(context: vscode.ExtensionContext) {
       }
     )
   );
-  let configChangeTimeout: ReturnType<typeof setTimeout> | undefined;
+  let restartTimeout: ReturnType<typeof setTimeout> | undefined;
+  let configRestartTimeout: ReturnType<typeof setTimeout> | undefined;
+
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(async (e) => {
       if (e.affectsConfiguration("chapel")) {
-        if (configChangeTimeout !== undefined) {
-          clearTimeout(configChangeTimeout);
+        logger.debug("Configuration changed, queuing server restart");
+        if (configRestartTimeout !== undefined) {
+          clearTimeout(configRestartTimeout);
         }
-        configChangeTimeout = setTimeout(async () => {
-          configChangeTimeout = undefined;
+        configRestartTimeout = setTimeout(async () => {
+          configRestartTimeout = undefined;
+          logger.debug("Restarting servers due to configuration change");
           Promise.all([
             chplcheckClient.resetConfig(getChplCheckConfig()),
             clsClient.resetConfig(getCLSConfig()),
@@ -166,13 +170,31 @@ export function activate(context: vscode.ExtensionContext) {
     "**/.cls-commands.json"
   );
   context.subscriptions.push(clsCommandWatcher);
-  let clsRestartTimeout: ReturnType<typeof setTimeout> | undefined;
   clsCommandWatcher.onDidChange(async () => {
-    if (clsRestartTimeout !== undefined) {
-      clearTimeout(clsRestartTimeout);
+    logger.debug(".cls-commands.json changed, queuing language server restart");
+    if (restartTimeout !== undefined) {
+      clearTimeout(restartTimeout);
     }
-    clsRestartTimeout = setTimeout(async () => {
-      clsRestartTimeout = undefined;
+    restartTimeout = setTimeout(async () => {
+      restartTimeout = undefined;
+      logger.debug("Restarting language server due to .cls-commands.json change");
+      await clsClient.stop();
+      await clsClient.start();
+    }, 5000);
+  });
+
+  const masonCommandWatcher = vscode.workspace.createFileSystemWatcher(
+    new vscode.RelativePattern(vscode.workspace.workspaceFolders?.[0] || "", "Mason.{toml,lock}")
+  );
+  context.subscriptions.push(masonCommandWatcher);
+  masonCommandWatcher.onDidChange(async () => {
+    logger.debug("Mason.toml or Mason.lock changed, queuing language server restart");
+    if (restartTimeout !== undefined) {
+      clearTimeout(restartTimeout);
+    }
+    restartTimeout = setTimeout(async () => {
+      restartTimeout = undefined;
+      logger.debug("Restarting language server due to Mason.toml or Mason.lock change");
       await clsClient.stop();
       await clsClient.start();
     }, 5000);


### PR DESCRIPTION
Helps improve some of the mason support in CLS by providing extra information to CLS.

CLS may invoke/use mason, so we want to provide the exact mason to use to CLS to invoke. However, this can only be done in 2.9.0, other CLS will crash with "unknown flag".

This PR also makes CLS restart on Mason.toml and Mason.lock changes, as that may effect resolution

This PR also fixes CLS/chplcheck to run with the env specified by the user