### PR TITLE
Remove workaround for installing latest NPM from 22

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,12 +18,6 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Use Latest NPM
-      run: |
-        # workaround https://github.com/nodejs/node/issues/62425#issuecomment-4200715930
-        npm install -g npm@10.9.8
-
-        npm install -g npm@latest
     - name: NPM install
       run: |
         npm ci


### PR DESCRIPTION
Remove the workaround for https://github.com/nodejs/node/issues/62425 added in [`9efd7b8` (#87)](https://github.com/chapel-lang/chapel-vscode/pull/87/changes/9efd7b852df004a3e1ac075dc45ccf45d4d4847a).

This causes the CI to correctly fail, whereas previously only the "Upload VSCode packages" workflow without the workaround was failing.