### PR TITLE
Remove 'npm ci' step before version bump

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,7 +31,6 @@ jobs:
         git push --set-upstream origin update-version
     - name: Bump Version
       run: |
-        npm ci
         npm version patch
         git push
     - name: create pull request


### PR DESCRIPTION
Remove running `npm ci` before `npm version patch` in the "Bump version" workflow, as it is not required (even if `npm ci` would fail) as tested on my local machine.

[@jabraham17 approved off-thread]