### PR TITLE
Update version of node and actions/setup-node used in workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,12 @@ jobs:
       run: |
         mkdir -p bin
         npx vsce package -o bin/chapel.vsix
+    - name: set artifact name
+      run: |
+        ARTIFACT_VER=$(sed "s/lts\/\*/lts-latest/g" <<< "${{ matrix.node-version }}")
+        echo "PACKAGE_ARTIFACT_NAME=chapel-package-node${ARTIFACT_VER}.vsix" >> "$GITHUB_ENV"
     - name: upload package
       uses: actions/upload-artifact@v4
       with:
-        name: chapel-package-node${{ matrix.node-version }}.vsix
+        name: ${{ env.PACKAGE_ARTIFACT_NAME }}
         path: bin/chapel.vsix

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [24]
     steps:
     - uses: actions/checkout@v4
     - name: Install Node.js

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [24]
+        node-version: [24, 26, lts/*, latest]
     steps:
     - uses: actions/checkout@v4
     - name: Install Node.js

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
     - name: Exit if branch exists
       run: |
         BRANCH_NAME="update-version"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: 24
+        node-version: lts/*
     - name: Exit if branch exists
       run: |
         BRANCH_NAME="update-version"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Node.js
       with:
-        node-version: 20
-      uses: actions/setup-node@v4
+        node-version: 24
+      uses: actions/setup-node@v6
     - name: NPM install
       run: |
         npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Node.js
       with:
-        node-version: 24
+        node-version: lts/*
       uses: actions/setup-node@v6
     - name: NPM install
       run: |


### PR DESCRIPTION
- Update `actions/setup-node` in `bump-version` and `publish` from `v4` to `v6`
- Use `node-version` `lts/*` in `bump-version` and `publish`
- Change CI `node-version` matrix from `20, 22, 24` to `24, 26, lts/*, latest`
  - Since the package artifact name is derived from the version and versions can't contain asterisks or slashes, add a step which determines the package name, substituting `lts/*` to `lts-latest`.