### PR TITLE
Enable Dependabot version updates for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 15
+    assignees:
+      - "jabraham17"


### PR DESCRIPTION
Modeled off of https://github.com/chapel-lang/chapel/blob/05f92306f3c055e19db0e6cb5e4d320c1bf15b87/.github/dependabot.yml.

Has a 15 day cooldown (waiting period) before updates are PR'd.

Will set @jabraham17 as the assignee for Dependabot PRs, so someone gets notified when a new one is created.