### PR TITLE
Add agent instructions and skills for mason projects

### DIFF
--- a/instructions/mason-UnitTest.instructions.md
+++ b/instructions/mason-UnitTest.instructions.md
@@ -1,0 +1,125 @@
+---
+name: 'Chapel mason UnitTest Guidelines'
+description: "Use when writing, editing, or reviewing Chapel UnitTests for mason projects (test/**/*.chpl). Covers the UnitTest module, assertions, setup/teardown with dependsOn and defer, skipping tests, and multi-locale tests."
+applyTo: test/**/*.chpl
+---
+# Chapel UnitTest Guidelines (mason)
+
+## File conventions
+- Place tests in the `test` directory with a `.chpl` extension.
+- Name files `test<Feature>.chpl` using CamelCase/PascalCase (e.g. `testRectangleArea.chpl`), where `<Feature>` describes what is tested.
+- Name test procedures descriptively for what they verify (e.g. `testCalculateRectangleArea`).
+
+## Basic structure
+Every test proc takes a `borrowed Test` argument. Call `UnitTest.main()` once at the end of the file.
+
+```chapel
+use UnitTest;
+
+proc test1(test: borrowed Test) throws {
+  // test code goes here
+  test.assertTrue(true); // example assertion, will always pass
+}
+
+UnitTest.main();
+```
+
+## Core rules
+- **Focused**: each test verifies a single aspect of the functionality.
+- **Independent**: one test's outcome must never affect another's; tests may run in any order.
+- **Repeatable**: a test must succeed on a second run. Clean up resources (temp files/dirs) it creates. Use `defer` for cleanup that must run whether the test passes or fails.
+- **Test bugs too**: if you find a bug (even a Chapel bug) while testing new code, still write the test with the *expected* output and tell the developer about the issue. Never leave buggy code untested, even if the test will fail.
+
+## Assertions
+Call these on the `test` argument:
+
+| Method | Asserts |
+|--------|---------|
+| `test.assertTrue(cond)` | `cond` is true |
+| `test.assertFalse(cond)` | `cond` is false |
+| `test.assertEqual(actual, expected)` | values are equal |
+| `test.assertNotEqual(actual, expected)` | values are not equal |
+| `test.assertGreaterThan(actual, expected)` | `actual > expected` |
+| `test.assertLessThan(actual, expected)` | `actual < expected` |
+| `test.assertClose(actual, expected)` | `actual` is within tolerance of `expected` |
+| `test.assertRegexMatch(actual, regex)` | `actual` matches `regex` exactly |
+
+- `assertRegexMatch` requires a full match. To match a substring, wrap the pattern with `.*` on both ends, or use `test.assertTrue(regex.search(actual))`.
+
+## Asserting thrown errors
+`errorType` must be a subclass of `Error`; `args` must be a tuple.
+
+```chapel
+test.assertThrows(func, errorType, args = (), match = "");
+```
+
+Only some functions work with `assertThrows`. When it does not fit, use try/catch manually:
+
+```chapel
+try {
+  functionThatThrows(arg1);
+  test.assertTrue(false); // fail, did not throw
+} catch e: ExpectedError {
+  test.assertEqual(e.message, "Expected error message"); // pass, threw as expected
+} catch {
+  test.assertTrue(false); // fail, threw unexpected error
+}
+```
+
+## Shared setup with dependsOn
+Use `test.dependsOn(setupProc)` to guarantee a setup proc runs before the test.
+
+```chapel
+use FileSystem;
+config const testTempDir = "/tmp/pathlib_test_temp_dir";
+
+proc createTempDir(test: borrowed Test) throws {
+  if FileSystem.exists(testTempDir) then FileSystem.rmTree(testTempDir);
+  FileSystem.mkdir(testTempDir);
+}
+
+proc testTouch(test: borrowed Test) throws {
+  test.dependsOn(createTempDir);
+  // test code that requires the temp directory goes here
+}
+```
+
+## Skipping tests
+Runtime skip (config-driven):
+
+```chapel
+config const optionalTests = false;
+proc myTest(test: borrowed Test) throws {
+  test.skipIf(!optionalTests);
+  // runs only when optionalTests is true
+}
+```
+
+Compile-time skip (platform/config-driven):
+
+```chapel
+use ChplConfig;
+proc myTest(test: borrowed Test) throws {
+  if CHPL_COMM == "none" {
+    test.skip("This test is not applicable when CHPL_COMM=none");
+    return;
+  }
+  // compiled only when CHPL_COMM != "none"
+}
+```
+
+## Multi-locale tests
+Tests run with the wrong locale count are skipped.
+- `test.addNumLocales(n)` — require exactly `n` locales.
+- `test.minLocales(n)` / `test.maxLocales(n)` — require a range.
+
+```chapel
+proc myTest(test: borrowed Test) throws {
+  test.minLocales(2);
+  test.maxLocales(4);
+  // requires between 2 and 4 locales
+}
+```
+
+## Style note
+These are guidelines, not hard rules. When adding tests to an existing file, match that file's established style. Follow these guidelines when creating a new test file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "20.x",
-        "@types/vscode": "^1.70.0",
+        "@types/vscode": "^1.104.0",
         "@typescript-eslint/eslint-plugin": "^8.3.5",
         "@typescript-eslint/parser": "^8.3.5",
         "@vscode/test-electron": "^2.3.6",
@@ -24,7 +24,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "vscode": "^1.70.0"
+        "vscode": "^1.104.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -428,7 +428,23 @@
       "[chapel]": {
         "editor.semanticHighlighting.enabled": true
       }
-    }
+    },
+    "chatInstructions": [
+      {
+        "path": "./instructions/mason-UnitTest.instructions.md"
+      }
+    ],
+    "chatSkills": [
+      {
+        "path": "./skills/chapel-mason-test/SKILL.md"
+      },
+      {
+        "path": "./skills/chapel-mason-build/SKILL.md"
+      },
+      {
+        "path": "./skills/chapel-mason-run/SKILL.md"
+      }
+    ]
   },
   "scripts": {
     "watch": "npm-run-all -p watch:*",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of development tools for programming in Chapel",
   "version": "0.0.21",
   "engines": {
-    "vscode": "^1.70.0"
+    "vscode": "^1.104.0"
   },
   "publisher": "chpl-hpe",
   "author": {
@@ -460,7 +460,7 @@
   },
   "devDependencies": {
     "@types/node": "20.x",
-    "@types/vscode": "^1.70.0",
+    "@types/vscode": "^1.104.0",
     "@typescript-eslint/eslint-plugin": "^8.3.5",
     "@typescript-eslint/parser": "^8.3.5",
     "@vscode/test-electron": "^2.3.6",

--- a/skills/chapel-mason-build/SKILL.md
+++ b/skills/chapel-mason-build/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: chapel-mason-build
+description: Compile (build) a Chapel mason project. Use only when the user wants to build or compile the package, or to surface compile errors. Do NOT use this to run the executable or to run tests. Run `mason build` in a terminal, or as a VS Code task of type `mason`.
+---
+
+# Build a Chapel mason project
+
+Compile a Chapel [mason](https://chapel-lang.org/docs/tools/mason/mason.html) package. A workspace is a mason project when it contains a `Mason.toml` file.
+
+There are two equally valid ways to build, both from the folder that contains `Mason.toml`:
+
+- **Terminal**: run `mason build`.
+- **VS Code task** of type `mason` (with `command: "build"`): this routes through the extension. For a task, set `cwd` to the `Mason.toml` folder (`${workspaceFolder}` when it is at the workspace root).
+
+## Build the package
+
+Run `mason build` — in a terminal, or as a task:
+
+```json
+{ "type": "mason", "command": "build" }
+```
+
+The extension also auto-provides a task with this definition, labeled `mason build`.
+
+## `mason` task properties
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `command` | Yes | Use `"build"` for this skill. |
+| `args` | No | Extra arguments appended after `build`. |
+| `cwd` | No | Folder containing `Mason.toml`. Defaults to the workspace root. |
+| `env` | No | Environment variables to set for the run. |
+
+To make a task reusable, add it to `.vscode/tasks.json` under `"tasks"` with a `"label"`, then run it by that label.
+
+## Tips
+
+- Build to surface compile errors before running or testing.
+- To run the built executable, use the `chapel-mason-run` skill. To run tests, use the `chapel-mason-test` skill.

--- a/skills/chapel-mason-run/SKILL.md
+++ b/skills/chapel-mason-run/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: chapel-mason-run
+description: Build and run the executable of a Chapel mason project. Use only when the user wants to run or execute the package's program. Do NOT use this to run tests (use chapel-mason-test) or to only compile (use chapel-mason-build). Run `mason run` in a terminal, or as a VS Code task of type `mason`.
+---
+
+# Run a Chapel mason project
+
+Build and run the executable of a Chapel [mason](https://chapel-lang.org/docs/tools/mason/mason.html) package. A workspace is a mason project when it contains a `Mason.toml` file.
+
+There are two equally valid ways to run, both from the folder that contains `Mason.toml`:
+
+- **Terminal**: run `mason run --build`.
+- **VS Code task** of type `mason` (with `command: "run"`): this routes through the extension. For a task, set `cwd` to the `Mason.toml` folder (`${workspaceFolder}` when it is at the workspace root).
+
+## Build and run the executable
+
+Run `mason run --build` (the `--build` flag compiles sources before running) — in a terminal, or as a task:
+
+```json
+{ "type": "mason", "command": "run", "args": ["--build"] }
+```
+
+The extension also auto-provides a task with this definition, labeled `mason run`.
+
+To pass arguments to the program, append them after `--build` (e.g. `mason run --build -- arg1 arg2`):
+
+```json
+{ "type": "mason", "command": "run", "args": ["--build", "--", "arg1", "arg2"] }
+```
+
+## `mason` task properties
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `command` | Yes | Use `"run"` for this skill. |
+| `args` | No | Extra arguments appended after `run`. Include `"--build"` to compile first. |
+| `cwd` | No | Folder containing `Mason.toml`. Defaults to the workspace root. |
+| `env` | No | Environment variables to set for the run. |
+
+To make a task reusable, add it to `.vscode/tasks.json` under `"tasks"` with a `"label"`, then run it by that label.
+
+## Tips
+
+- To only compile without running, use the `chapel-mason-build` skill. To run tests, use the `chapel-mason-test` skill.

--- a/skills/chapel-mason-test/SKILL.md
+++ b/skills/chapel-mason-test/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: chapel-mason-test
+description: Run the tests of a Chapel mason project, including a single test file. Use whenever the user wants to run, re-run, or check Chapel tests in a workspace that contains a Mason.toml file. Do NOT use this to build the package or run its executable. Run `mason test` in a terminal, or as a VS Code task of type `mason`
+---
+
+# Test a Chapel mason project
+
+Run the tests in a Chapel [mason](https://chapel-lang.org/docs/tools/mason/mason.html) package. A workspace is a mason project when it contains a `Mason.toml` file.
+
+There are two equally valid ways to run tests, both from the folder that contains `Mason.toml`:
+
+- **Terminal**: run `mason test ...` directly.
+- **VS Code task** of type `mason` (with `command: "test"`): this routes through the extension. For a task, set `cwd` to the `Mason.toml` folder (`${workspaceFolder}` when it is at the workspace root).
+
+## Run a single test file (most common)
+
+To run one test file (e.g. after creating `test/testRectangleArea.chpl`), pass the file as the last argument after `--`.
+
+Terminal:
+
+```sh
+mason test --show -- test/testRectangleArea.chpl
+```
+
+Or as a task:
+
+```json
+{
+  "type": "mason",
+  "command": "test",
+  "args": ["--show", "--", "test/testRectangleArea.chpl"]
+}
+```
+
+The file path is relative to the `Mason.toml` directory. `--show` streams the test output.
+
+To run one named test within the file, add a filter before `--` (e.g. `mason test --show --filter=testCalculateRectangleArea -- test/testRectangleArea.chpl`):
+
+```json
+{
+  "type": "mason",
+  "command": "test",
+  "args": ["--show", "--filter=testCalculateRectangleArea", "--", "test/testRectangleArea.chpl"]
+}
+```
+
+## Run the whole test suite
+
+Run `mason test` with no file argument — in a terminal, or as a task:
+
+```json
+{ "type": "mason", "command": "test" }
+```
+
+The extension also auto-provides a task with this definition, labeled `mason test`.
+
+## `mason` task properties
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `command` | Yes | Use `"test"` for this skill. |
+| `args` | No | Extra arguments appended after `test`. For a single test file: `["--show", "--", "<file>"]`. |
+| `cwd` | No | Folder containing `Mason.toml`. Defaults to the workspace root. |
+| `env` | No | Environment variables to set for the run. |
+
+To make a task reusable, add it to `.vscode/tasks.json` under `"tasks"` with a `"label"`, then run it by that label.
+
+## Tips
+
+- If tests fail to compile, build the package first (see the `chapel-mason-build` skill) to surface compile errors.
+- Mason package test files live in the `test/` directory. See the Chapel UnitTest guidelines for how tests are structured.


### PR DESCRIPTION
Adds some agent instructions for writing/running mason unit tests

This requires a newer version of vscode to work, so that requirement is also bumped in this PR